### PR TITLE
Try setting TCP no delay on underlying net socket

### DIFF
--- a/src/ws-server.js
+++ b/src/ws-server.js
@@ -12,6 +12,10 @@ module.exports = function attachWSS (server) {
 
   console.log('websocket server created')
   wss.on('connection', function (ws) {
+    
+    // HACK: use internal socket object to disable Nagle's algorithm
+    ws._socket.setNoDelay();
+    
     ws.broadcast = function broadcast (data, flags) {
       wss.clients.forEach(function bc (client) {
         if (client === ws) return


### PR DESCRIPTION
I'm not really set up to test this, but here's an attempt to disable one possible source of note messages getting "bunched up". It could be that they are getting bunched up at the TCP level by [Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm). There's probably other places in the various plumbing where they might get bunched up too, but I figure this is an easy one to see if it makes a difference.
